### PR TITLE
v0.3.2beta

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,35 @@
 #  Setup Checklist - Change Log
 
+## v0.3.2
+(2026-03-05)
+
+### Setup Checklist
+
+- Setup Checklist now works with Jamf School
+- Steps:
+  - wallpaper: 
+    - can handle a larger number of image files (#16)
+    - enabling `mayKeepCurrent` allows user to continue without changing
+  - script: 
+    - added `USER` and `HOME` to environment of scripts
+  - defaultApp: 
+    - errors when none of the bundle-ids are installed
+- improved process clean up on closed window
+- improved determination of movie size
+- improved concurrency behaviors
+
+### Welcome app
+
+- added `buttonColor` and `titleColor` to override default colors (#12)
+- added `titleFont`, `titleFontSize`, and `titleFontStyle`
+- added `blur` key to control background blur
+- added animation
+
+### General
+
+- several documentation fixes
+
+
 ## v0.3.1
 
 (2026-02-26)

--- a/Examples/Setup Checklist Complete.mobileconfig
+++ b/Examples/Setup Checklist Complete.mobileconfig
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Setup Checklist - Welcome Screen</string>
+			<key>PayloadIdentifier</key>
+			<string>com.jamf.setup.welcome</string>
+			<key>PayloadType</key>
+			<string>com.jamf.setup.welcome</string>
+			<key>PayloadUUID</key>
+			<string>3886DFAB-9055-4399-8B3E-DC9E168BD709</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>background</key>
+			<string>/Library/Desktop Pictures/6-JamfPearl.png</string>
+			<key>languages</key>
+			<array>
+				<string>en-US</string>
+				<string>en-GB</string>
+				<string>de</string>
+				<string>fr</string>
+				<string>nl</string>
+			</array>
+			<key>showLanguages</key>
+			<true/>
+			<key>showWelcome</key>
+			<true/>
+			<key>title</key>
+			<dict>
+				<key>de</key>
+				<string>Willkommen bei Jamf</string>
+				<key>en</key>
+				<string>Welcome to Jamf</string>
+				<key>fr</key>
+				<string>Bienvenue à Jamf</string>
+				<key>nl</key>
+				<string>Welkom bij Jamf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Setup Checklist</string>
+			<key>PayloadIdentifier</key>
+			<string>com.jamf.setupchecklist</string>
+			<key>PayloadType</key>
+			<string>com.jamf.setupchecklist</string>
+			<key>PayloadUUID</key>
+			<string>3448A740-ACEF-46CF-AAE5-AB3A55946E28</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>accentColor</key>
+			<string>##green</string>
+			<key>hideOtherApps</key>
+			<false/>
+			<key>icon</key>
+			<string>name:Checklist</string>
+			<key>message</key>
+			<string>Let's configure your new Mac!</string>
+			<key>showIconInDock</key>
+			<true/>
+			<key>steps</key>
+			<array>
+				<dict>
+					<key>icon</key>
+					<string>symbol:slider.horizontal.2.square.on.square</string>
+					<key>identifier</key>
+					<string>welcome-message</string>
+					<key>image</key>
+					<string>name:Computer</string>
+					<key>kind</key>
+					<string>message</string>
+					<key>message</key>
+					<dict>
+						<key>de</key>
+						<string>Nur noch ein paar Schritte, um Ihren neuen Mac zu konfigurieren.</string>
+						<key>en</key>
+						<string>Just a few more steps to configure your new Mac.</string>
+						<key>fr</key>
+						<string>Juste quelques étapes de plus pour configurer votre nouveau Mac.</string>
+						<key>nl</key>
+						<string>Nog een paar stappen om je nieuwe Mac te configureren.</string>
+					</dict>
+					<key>title</key>
+					<dict>
+						<key>de</key>
+						<string>Willkommen bei Setup Checklist</string>
+						<key>en</key>
+						<string>Welcome to Setup Checklist</string>
+						<key>fr</key>
+						<string>Bienvenue à Setup Checklist</string>
+						<key>nl</key>
+						<string>Welkom bij Setup Checklist</string>
+					</dict>
+				</dict>
+				<dict>
+					<key>identifier</key>
+					<string>wallpaper</string>
+					<key>kind</key>
+					<string>wallpaper</string>
+					<key>message</key>
+					<dict>
+						<key>de</key>
+						<string>Bitte wählen Sie ein Hintergrundbild aus unserer Liste. Sie können es später jederzeit ändern.</string>
+						<key>en</key>
+						<string>Please choose a wallpaper from our list of branded images. You can always change it later.</string>
+						<key>fr</key>
+						<string>Veuillez choisir un fond d'écran dans notre liste d'images. Vous pouvez toujours le changer plus tard.</string>
+						<key>nl</key>
+						<string>Kies een achtergrond uit onze lijst met afbeeldingen. Je kunt het altijd later veranderen.</string>
+					</dict>
+					<key>path</key>
+					<string>/Library/Desktop Pictures/</string>
+					<key>title</key>
+					<dict>
+						<key>de</key>
+						<string>Hintergrundbild wählen</string>
+						<key>en</key>
+						<string>Choose a wallpaper</string>
+						<key>fr</key>
+						<string>Choisir un fond d'écran</string>
+						<key>nl</key>
+						<string>Kies een achtergrond</string>
+					</dict>
+				</dict>
+				<dict>
+					<key>bundle-id</key>
+					<string>com.microsoft.edgemac</string>
+					<key>icon</key>
+					<string>symbol:network</string>
+					<key>identifier</key>
+					<string>default-app-browser</string>
+					<key>kind</key>
+					<string>defaultApp</string>
+					<key>mayKeepCurrent</key>
+					<false/>
+					<key>message</key>
+					<dict>
+						<key>de</key>
+						<string>Microsoft Edge als Standardbrowser bestätigen.</string>
+						<key>en</key>
+						<string>Confirm Microsoft Edge as default browser.</string>
+						<key>fr</key>
+						<string>Confirmer Microsoft Edge comme navigateur par défaut.</string>
+						<key>nl</key>
+						<string>Bevestig Microsoft Edge als standaardbrowser.</string>
+					</dict>
+					<key>title</key>
+					<dict>
+						<key>de</key>
+						<string>Standardbrowser bestätigen</string>
+						<key>en</key>
+						<string>Confirm Default Browser</string>
+						<key>fr</key>
+						<string>Confirmer Navigateur par défaut</string>
+						<key>nl</key>
+						<string>Standaardbrowser bevestigen</string>
+					</dict>
+					<key>urlScheme</key>
+					<string>http</string>
+				</dict>
+				<dict>
+					<key>bundle-id</key>
+					<string>com.microsoft.Outlook</string>
+					<key>icon</key>
+					<string>symbol:mail</string>
+					<key>identifier</key>
+					<string>default-app-mail</string>
+					<key>kind</key>
+					<string>defaultApp</string>
+					<key>mayKeepCurrent</key>
+					<true/>
+					<key>message</key>
+					<dict>
+						<key>de</key>
+						<string>Wähle deine bevorzugte app für Email.</string>
+						<key>en</key>
+						<string>Choose your preferred app for email.</string>
+						<key>fr</key>
+						<string>Choisissez votre application préférée pour le courrier électronique.</string>
+						<key>nl</key>
+						<string>Kies uw favoriete app voor e-mail.</string>
+					</dict>
+					<key>title</key>
+					<dict>
+						<key>de</key>
+						<string>Email App wählen</string>
+						<key>en</key>
+						<string>Choose Mail App</string>
+						<key>fr</key>
+						<string>Choisir l'application Mail</string>
+						<key>nl</key>
+						<string>Kies de Mail-app</string>
+					</dict>
+					<key>urlScheme</key>
+					<string>mailto</string>
+				</dict>
+				<dict>
+					<key>bundle-id</key>
+					<array>
+						<string>com.microsoft.teams2</string>
+						<string>us.zoom.xos</string>
+					</array>
+					<key>icon</key>
+					<string>symbol:rectangle.on.rectangle.angled</string>
+					<key>identifier</key>
+					<string>screensharing</string>
+					<key>kind</key>
+					<string>screensharing</string>
+					<key>message</key>
+					<dict>
+						<key>de</key>
+						<string>Aktiviere die Aufnahme von BIldschirm &amp; Systemaudio für Microsoft Teams</string>
+						<key>en</key>
+						<string>Enable Screen &amp; System Audio Recording for Microsoft Teams</string>
+						<key>fr</key>
+						<string>Activer l'enregistrement de l'écran et des sons du système pour Microsoft Teams</string>
+						<key>nl</key>
+						<string>Scherm- en systeemaudio-opname inschakelen voor Microsoft Teams</string>
+					</dict>
+					<key>openAutomatically</key>
+					<true/>
+					<key>title</key>
+					<dict>
+						<key>de</key>
+						<string>Bildschirmfreigabe</string>
+						<key>en</key>
+						<string>Screen Sharing</string>
+						<key>fr</key>
+						<string>Partage d’écran</string>
+						<key>nl</key>
+						<string>Schermdeling</string>
+					</dict>
+					<key>windowPosition</key>
+					<string>right</string>
+				</dict>
+				<dict>
+					<key>icon</key>
+					<string>symbol:hands.and.sparkles</string>
+					<key>identifier</key>
+					<string>thankyou-message</string>
+					<key>kind</key>
+					<string>message</string>
+					<key>message</key>
+					<dict>
+						<key>de</key>
+						<string>Die Konfiguration is abgeschlossen. Sie können diese Einstellungen wiederholen, indem sie die Welcome.app wieder starten. Viel Vergnügen mit Ihrem Mac!</string>
+						<key>en</key>
+						<string>The configuration is complete. You can re-apply these settings by running the Welcome.app again. Enjoy your Mac!</string>
+						<key>fr</key>
+						<string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l'application Welcome. Profitez de votre Mac!</string>
+						<key>nl</key>
+						<string>De configuratie is voltooid. U kunt deze instellingen opnieuw toepassen door de Welcome.app opnieuw uit te voeren. Veel plezier met uw Mac!</string>
+					</dict>
+					<key>title</key>
+					<dict>
+						<key>de</key>
+						<string>Danke schön</string>
+						<key>en</key>
+						<string>Thank you</string>
+						<key>fr</key>
+						<string>Merci</string>
+						<key>nl</key>
+						<string>Bedankt</string>
+					</dict>
+				</dict>
+			</array>
+			<key>title</key>
+			<string>Checklist</string>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Setup Checklist - PPPC</string>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>6819A836-793F-4408-ADA7-55AAE949F4C4</string>
+			<key>PayloadType</key>
+			<string>com.apple.TCC.configuration-profile-policy</string>
+			<key>PayloadUUID</key>
+			<string>6819A836-793F-4408-ADA7-55AAE949F4C4</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Services</key>
+			<dict>
+				<key>SystemPolicyAllFiles</key>
+				<array>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>anchor apple generic and identifier "com.jamf.setupchecklist" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "483DWKW443")</string>
+						<key>Identifier</key>
+						<string>com.jamf.setupchecklist</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<false/>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Setup Checklist - Login Items</string>
+			<key>PayloadIdentifier</key>
+			<string>13887830-5198-4FF4-9E70-7B82182D9F13</string>
+			<key>PayloadType</key>
+			<string>com.apple.servicemanagement</string>
+			<key>PayloadUUID</key>
+			<string>13887830-5198-4FF4-9E70-7B82182D9F13</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Rules</key>
+			<array>
+				<dict>
+					<key>RuleType</key>
+					<string>BundleIdentifier</string>
+					<key>RuleValue</key>
+					<string>com.jamf.setupchecklist</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Setup Checklist</string>
+	<key>PayloadIdentifier</key>
+	<string>com.jamf.setupchecklist</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>DDF8A7BB-C542-4C90-9E7E-ADAE327F5AE1</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/Examples/SetupChecklistPPPCLogin.mobileconfig
+++ b/Examples/SetupChecklistPPPCLogin.mobileconfig
@@ -7,8 +7,6 @@
     <string>2B97D645-ABDE-44E5-8B8B-301BDF34E8A2</string>
     <key>PayloadType</key>
     <string>Configuration</string>
-    <key>PayloadOrganization</key>
-    <string>Armin Briegel</string>
     <key>PayloadIdentifier</key>
     <string>2B97D645-ABDE-44E5-8B8B-301BDF34E8A2</string>
     <key>PayloadDisplayName</key>
@@ -30,12 +28,10 @@
         <string>6819A836-793F-4408-ADA7-55AAE949F4C4</string>
         <key>PayloadType</key>
         <string>com.apple.TCC.configuration-profile-policy</string>
-        <key>PayloadOrganization</key>
-        <string>Armin Briegel</string>
         <key>PayloadIdentifier</key>
         <string>6819A836-793F-4408-ADA7-55AAE949F4C4</string>
         <key>PayloadDisplayName</key>
-        <string>PRIVACY_PREFERENCES_POLICY_CONTROL</string>
+        <string>Setup Checklist - PPPC</string>
         <key>PayloadDescription</key>
         <string />
         <key>PayloadVersion</key>
@@ -63,11 +59,9 @@
       </dict>
       <dict>
         <key>PayloadDisplayName</key>
-        <string>Managed Login Items</string>
+        <string>Setup Checklist - Login Items</string>
         <key>PayloadIdentifier</key>
         <string>13887830-5198-4FF4-9E70-7B82182D9F13</string>
-        <key>PayloadOrganization</key>
-        <string>JAMF Software</string>
         <key>PayloadType</key>
         <string>com.apple.servicemanagement</string>
         <key>PayloadUUID</key>

--- a/Examples/com.jamf.setupchecklist.plist
+++ b/Examples/com.jamf.setupchecklist.plist
@@ -9,7 +9,7 @@
 	<key>icon</key>
 	<string>name:Checklist</string>
 	<key>message</key>
-	<string>Let's configure your new Mac!</string>
+	<string>Let&apos;s configure your new Mac!</string>
 	<key>showIconInDock</key>
 	<true/>
 	<key>steps</key>
@@ -51,6 +51,8 @@
 			<string>wallpaper</string>
 			<key>kind</key>
 			<string>wallpaper</string>
+			<key>path</key>
+			<string>/Library/Desktop Pictures/</string>
 			<key>message</key>
 			<dict>
 				<key>de</key>
@@ -58,11 +60,9 @@
 				<key>en</key>
 				<string>Please choose a wallpaper from our list of branded images. You can always change it later.</string>
 				<key>fr</key>
-				<string>Veuillez choisir un fond d'écran dans notre liste d'images. Vous pouvez toujours le changer plus tard.</string>
+				<string>Veuillez choisir un fond d&apos;écran dans notre liste d&apos;images. Vous pouvez toujours le changer plus tard.</string>
 				<key>nl</key>
 				<string>Kies een achtergrond uit onze lijst met afbeeldingen. Je kunt het altijd later veranderen.</string>
-				<key>path</key>
-				<string>/Library/Desktop Pictures/</string>
 			</dict>
 			<key>title</key>
 			<dict>
@@ -71,7 +71,7 @@
 				<key>en</key>
 				<string>Choose a wallpaper</string>
 				<key>fr</key>
-				<string>Choisir un fond d'écran</string>
+				<string>Choisir un fond d&apos;écran</string>
 				<key>nl</key>
 				<string>Kies een achtergrond</string>
 			</dict>
@@ -141,7 +141,7 @@
 				<key>en</key>
 				<string>Choose Mail App</string>
 				<key>fr</key>
-				<string>Choisir l'application Mail</string>
+				<string>Choisir l&apos;application Mail</string>
 				<key>nl</key>
 				<string>Kies de Mail-app</string>
 			</dict>
@@ -167,7 +167,7 @@
 				<key>en</key>
 				<string>Enable Screen &amp; System Audio Recording for Microsoft Teams</string>
 				<key>fr</key>
-				<string>Activer l'enregistrement de l'écran et des sons du système pour Microsoft Teams</string>
+				<string>Activer l&apos;enregistrement de l&apos;écran et des sons du système pour Microsoft Teams</string>
 				<key>nl</key>
 				<string>Scherm- en systeemaudio-opname inschakelen voor Microsoft Teams</string>
 			</dict>
@@ -201,7 +201,7 @@
 				<key>en</key>
 				<string>The configuration is complete. You can re-apply these settings by running the Welcome.app again. Enjoy your Mac!</string>
 				<key>fr</key>
-				<string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l'application Welcome. Profitez de votre Mac!</string>
+				<string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l&apos;application Welcome. Profitez de votre Mac!</string>
 				<key>nl</key>
 				<string>De configuratie is voltooid. U kunt deze instellingen opnieuw toepassen door de Welcome.app opnieuw uit te voeren. Veel plezier met uw Mac!</string>
 			</dict>

--- a/Extras/CommandLineTool.md
+++ b/Extras/CommandLineTool.md
@@ -83,7 +83,6 @@ The values you can use are:
 - `image`
 - `iconColor`
 - `windowPosition`
-- `image`
 - `movie`
 - `accentColor`
 - `item`

--- a/Extras/Telemetry.md
+++ b/Extras/Telemetry.md
@@ -9,5 +9,3 @@ No signals are sent when `DEBUG` is set to `true`.
 We use this data to determine the usage of the app and where to focus future development, so we appreciate when you let us gather this data.
 
 You can suppress the tracking signal by setting the `PLEASE_DO_NOT_TRACK` boolean key to `true` in the configuration profile.
-
-

--- a/Profile/Overview.md
+++ b/Profile/Overview.md
@@ -2,7 +2,7 @@
 
 Setup Checklist is a Jamf-powered tool that presents users with a guided experience on their new Mac.
 
-You define the steps, like setting or choosing default apps, configure permissions, choose wallpapers, and users work through them at first login. Configured with configuration profiles, supports localization, and integrates with your existing Jamf workflows.
+You (the admin) define the steps, like setting or choosing default apps, configure permissions, choose wallpapers, and users work through them at first login. Configured with configuration profiles, supports localization, and integrates with your existing Jamf workflows.
 
 The onboarding setup checklist that helps users complete required setup tasks before they start working.
 
@@ -10,9 +10,11 @@ The onboarding setup checklist that helps users complete required setup tasks be
 
 Setup Checklist is comprised of two apps. The main Setup Checklist app and a helper app called "Welcome" which displays the initial full screen welcome message and language chooser. This allows the Welcome app to change the language and localization settings Setup Checklist and other apps, before they launch.
 
-You can skip the the full screen welcome message by setting the `showWelcome` key in the Welcome app's Profile to `true`.
+You can skip the full screen welcome message by setting the `showWelcome` key in the Welcome app's Profile to `false`.
 
 ## Installation
+
+Setup Checklist works with and _requires_ a Mac managed with either Jamf Pro or Jamf School. When the Mac is managed with Jamf School [the Scripting Module _must_ be enabled](https://learn.jamf.com/en-US/bundle/jamf-school-documentation/page/Scripts.html).
 
 Download [the latest pkg installer file](https://github.com/Jamf-Concepts/setup-checklist/releases/latest) from releases.
 

--- a/Profile/SetupChecklist.md
+++ b/Profile/SetupChecklist.md
@@ -49,7 +49,7 @@ Short message shown under the icon and title in the sidebar.
 
 #### Accent Color
 
-key: `accentColor`, String/[color definition](../Extras/DefiningColors.md), optional, default: system accent color
+key: `accentColor`, string/[color definition](../Extras/DefiningColors.md), optional, default: system accent color
 
 Sets the accent color for buttons, progress bar, SF Symbols, and other UI elements. Use this to match branding. See ['Defining Colors'](../Extras/DefiningColors.md) for details.
 
@@ -67,7 +67,7 @@ Examples:
 
 #### Hide other Apps
 
-key: `hideOtherApps`, Boolean, optional, default: `true`
+key: `hideOtherApps`, boolean, optional, default: `true`
 
 Controls whether other apps are hidden at launch. Other apps are _not_ hidden when running in DEBUG mode.
 
@@ -80,7 +80,7 @@ Example:
 
 #### Open When Finished
 
-key: `openWhenFinished`, String, optional
+key: `openWhenFinished`, string, optional
 
 When set, this item will be opened when the user clicks "Done" on the last step and Setup Checklist quits. This item can be written as an absolute path, e.g. `/Applications/Self Service+.app`, a URL scheme, e.g. `jamfselfservice:`, or an app bundle identifer, e.g. `com.jamf.selfserviceplus`.
 
@@ -93,7 +93,7 @@ Example:
 
 #### Show Icon in Dock
 
-key: `showIconInDock`, Boolean, optional, default: `true`
+key: `showIconInDock`, boolean, optional, default: `true`
 
 Controls whether app icon is shown in the Dock. Icon will _always_ show in Dock when running in DEBUG mode.
 
@@ -240,7 +240,7 @@ Example:
   <key>identifier</key>
   <string>message-thankyou</string>
   <key>image</key>
-  <string>/Library/Branding/BrandImage.png
+  <string>/Library/Branding/BrandImage.png</string>
   <key>kind</key>
   <string>message</string>
   <key>message</key>
@@ -277,6 +277,11 @@ key: `path`, string, optional, default: `/Library/Desktop Pictures`
 
 All image files in this folder will be presented.
 
+#### May keep current
+
+key; `mayKeepCurrent`, boolean, optional, default: false
+
+When this key is enabled, the user can continue without changing the wallpaper.
 
 ### Open
 
@@ -348,7 +353,7 @@ kind: `defaultApp`
 
 Prompts the user to confirm or choose an app as the default for a url scheme (e.g. `http` or `mailto`) or unified type identifier (e.g. `public.txt` or `com.adobe.pdf`).
 
-![Setup Checklist defaultApp step keys](../Images/SetupChecklist-defaultApp-keys.png)
+![Setup Checklist defaultApp step keys](../Images/SetupChecklist-browser-keys.png)
 
 Example: 
 
@@ -497,7 +502,7 @@ This step will open the Screen Recording pane in Settings > Privacy & Security a
 
 This step works well with a `windowPosition` setting of `left` or `right`
 
-![Setup Checklist browser step keys](../Images/SetupChecklist-screensharing-keys.png)
+![Setup Checklist screensharing step keys](../Images/SetupChecklist-screensharing-keys.png)
 
 Example: 
 
@@ -579,6 +584,25 @@ You can find [a detailed discussion of an example implementation here](ScriptSte
 
 The `script` step is based on the `open` step, so all those keys are available here as well. In addition you get a number of keys to provide scripts to influence the step's behavior. All keys are optional and default behavior is described in each script description.
 
+**Warning:** _Here there be dragons!_
+
+This step allows you to define your own behavior, but this also means that errors in the script could lead to unwanted or even detrimental outcomes. Setup Checklist runs with user privileges, so scripts launched here can only affect user space, but there is still a lot of damage that could occur here.
+
+While we hope there will be many good examples for script steps byt other Mac Admins, you should not trust any of these blindly and without understanding the code and testing.
+
+_Always test thoroughly!_
+
+#### Debug mode
+
+**Important:** Setup Checklist will execute the scripts defined for this step, _even when debug mode is enabled_. The script will not respect debug mode _unless_ you write that behavior into them. You can check for debug mode within a script by checking the `DEBUG` environment variable.
+
+```sh
+if [ -n $DEBUG ]; then
+  echo "debug mode enabled, stopping"
+  exit 0
+fi
+```
+
 #### Lifecycle
 
 App launches/Step is loaded:
@@ -609,8 +633,6 @@ Continue Button clicked:
 - `willContineScript`
 
 The polling cycle is also stopped when the user selects a different step from the list.
-
-**Note:** `shell` scripts will _not_ respect the `DEBUG` key. You can add checks to your script by checking the value of the DEBUG key with `defaults read com.jamf.setupmanager DEBUG`.
 
 #### Prepare Script
 

--- a/Profile/Welcome.md
+++ b/Profile/Welcome.md
@@ -40,7 +40,7 @@ Skip Welcome screen (and language chooser)
 
 #### Title
 
-key: `title`, string, optional, [localizable](Localization.md), default: `Welcome`, localized to current language
+key: `title`, string, optional, [localizable](../Extras/Localization.md), default: `Welcome`, localized to current language
 
 Use this to customize the welcome message shown. When there is a single string value, it will be used for all languages. When the localization dict does not provide a localization for the current language, it will fall back to the `en` localization
 
@@ -75,13 +75,67 @@ key: `background`, string, optional, default: default system background image
 
 Local path to an image that is used as the background for the welcome screen.
 
-(**Note:** this does not use the [image source](ImageSources.md) syntax yet.)
+(**Note:** this does _not_ use the [image source](../Extras/ImageSources.md) syntax yet.)
 
 Example:
 
 ```xml
 <key>background</key>
 <string>/Library/Desktop Pictures/Jamf.png</string>
+```
+
+#### Background Blur
+
+key: `blur`, boolean, optional, default: true
+
+Controls whether the background image is blurred (default) or not.
+
+Example:
+
+```xml
+<key>blur</key>
+<false/>
+```
+
+#### Title Color, Button Color
+
+key: `titleColor`, string/[color definition](../Extras/DefiningColors.md), optional
+key: `buttonColor`, string/[color definition](../Extras/DefiningColors.md), optional
+
+By default, the Welcome app calculates the overall "lightness" of the background image and displays the title text and the buttons in a white font color for dark images and and black font color for light images.
+
+For certain images that might not work so well, e.g. when the top two thirds are light and the lower third is predominantly dark, a black font will be chosen and the buttons will not have good contrast. Or you might want to choose a different color for branding.
+
+Use this key to override the the default, calculated colors.
+
+Example:
+
+```xml
+<key>buttonColor</key>
+<string>##yellow</string>
+<key>titleColor</key>
+<string>##blue</string>
+```
+
+#### Title Font, Size, and Style
+
+key: `titleFont`, string, optional, default: system font (Helevetica Neue)
+key: `titleFontSize`, number, optional, default: 60
+key: `titleFontStyle`, string, optional
+
+These keys change the font, size and style of the 'Welcome' message on the full screen.
+
+The style needs to match an available style of the font. Check the Font Book app to see which styles a font has available. You can combine two or more styles, e.g. `semibold italic condensed`, when available.
+
+Example:
+
+```xml
+<key>titleFont</key>
+<string>SF Pro Rounded</string>
+<key>titleFontSize</key>
+<integer>120</integer>
+<key>titleFontStyle</key>
+<string>semibold</string>
 ```
 
 #### Show Languages
@@ -115,7 +169,7 @@ By default, the language chooser shows all languages available in macOS. You can
 Example:
 
 ```xml
-	<key>languages-disabled</key>
+	<key>languages</key>
 	<array>
 		<string>en-US</string>
 		<string>en-GB</string>

--- a/README.md
+++ b/README.md
@@ -10,10 +10,19 @@
 
 ## What it does
 
-First login experience powered by Jamf
+**First login experience powered by Jamf**
 
-Updates are published in the '[Releases](https://github.com/Jamf-Concepts/setup-checklist/releases)' section of the repo. There you can also [download the latest pkg installer](https://github.com/Jamf-Concepts/setup-checklist/releases/latest). You can subscribe to notifications for the repo using the 'Watch' button above.
+The enrollment is done, [apps and tools are installed](https://github.com/jamf/setup-manager), the user account created... now they can start working, right!?
 
+Unfortunately, not quite. Even in the best managed deployment, there are some Apple services and third party apps and tools that will need just some more setup. Either Apple deems the settings so privacy sensitive that they require user approval, such as setting the default browser or providing screen recording access to video conferencing apps. Many third party apps and tools require the user to log in, and do some configuration. And sometimes, we (as the admins) just want to give the user a heads up, or a _choice_.
+
+We have seen several approaches to this. From guided sessions in a classroom where users setup their Macs, to papers or PDFs with instructions handed out with the Macs, to massive scripts using various tools to guide the user.
+
+Setup Checklist is our solution to unify this in a nice and manageable way.
+
+Admins can deploy Setup Checklist together with configuration profile to guide the user through these last necessary steps to the Mac ready to go!
+
+Setup Checklist works with **Jamf Pro** and **Jamf School**.
 
 ## BETA Warning!
 
@@ -21,13 +30,10 @@ This tool is still in beta. While we do test the app and do our best to make sur
 
 This also means that features and the format of the configuration profile might change from one beta version to the next. We will do our best to document these changes, but be prepared that you might have to update the configuration profile you built frequently.
 
-## Feedback
+## Installer and Updates
 
-Please report issues, feature requests [as an issue.](https://github.com/Jamf-Concepts/setup-checklist/issues)
+Updates are published in the '[Releases](https://github.com/Jamf-Concepts/setup-checklist/releases)' section of the repo. There you can also [download the latest pkg installer](https://github.com/Jamf-Concepts/setup-checklist/releases/latest). You can subscribe to notifications for the repo using the 'Watch' button above.
 
-We have opened the [discussions](https://github.com/Jamf-Concepts/setup-checklist/discussions) area for questions and more generic feedback.
-
-There is also a [`#jamf-setup-checklist`](https://macadmins.slack.com/archives/C0A4J4Q3ZHC) channel on the [MacAdmins Slack](https://macadmins.org).
 
 ## Documentation
 
@@ -49,7 +55,14 @@ There is also a [`#jamf-setup-checklist`](https://macadmins.slack.com/archives/C
 ## Known Issues (and Plans)
 
 - there is a limited number of steps right now, we have plans for more, but your feedback on which kinds of steps you need is appreciated and will help us prioritize
-- currently, Setup Checklist only works with Jamf Pro. We want to extend that Jamf School soon.
 - `background` key in Welcome screen only allows local files
 - there is no custom JSON to get a custom profile interface in Jamf Pro and we are not planning to provide one until the profile schema is stable
 - there is known issue in Self Service Plus where launching an action through a URL stalls in Self Service Plus
+
+## Feedback
+
+Please report issues, feature requests [as an issue.](https://github.com/Jamf-Concepts/setup-checklist/issues)
+
+We have opened the [discussions](https://github.com/Jamf-Concepts/setup-checklist/discussions) area for questions, support and more generic feedback. You can also share solutions or your Setup Checklist workflow there!
+
+There is also a [`#jamf-setup-checklist`](https://macadmins.slack.com/archives/C0A4J4Q3ZHC) channel on the [MacAdmins Slack](https://macadmins.org).


### PR DESCRIPTION
### Setup Checklist

- Setup Checklist now works with Jamf School
- Steps:
  - wallpaper: 
    - can handle a larger number of image files (#16)
    - enabling `mayKeepCurrent` allows user to continue without changing
  - script: 
    - added `USER` and `HOME` to environment of scripts
  - defaultApp: 
    - errors when none of the bundle-ids are installed
- improved process clean up on closed window
- improved determination of movie size
- improved concurrency behaviors

### Welcome app

- added `buttonColor` and `titleColor` to override default colors (#12)
- added `titleFont`, `titleFontSize`, and `titleFontStyle`
- added `blur` key to control background blur
- added animation

### General

- several documentation fixes