### PR TITLE
v0.4.0.beta

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,33 @@
 #  Setup Checklist - Change Log
 
+## v0.4.0
+(2026-04-09)
+
+### Setup Checklist
+
+- NEW: `dock` step kind (#17)
+- added `buttonLabel` key to `open`, `script`, and `screensharing` steps to override button label text
+- improved scrolling and responsiveness of `wallpaper` with many images
+- localization fixes (#42)
+- added toolbar button to show list when it is hidden
+- fixed a user interface issue where the action button disappears when window is not active
+- images and movies scale up when window size is increased
+
+### Welcome app
+
+- fixed an issue where the welcome screen may not go full screen
+
+### General
+
+- added uninstall script
+- documentation updates (#45)
+
+### Deprecations and Removals
+
+- `browser` step kind has been _removed_. Use `defaultApp` with a `urlScheme` of `http` instead
+- `actionButtonLabel` and `actionButtonScript` keys are simplified to `buttonLabel` and `buttonScript`. The old long forms will keep working for now, but be removed in some future update. (#43)
+
+
 ## v0.3.4
 (2026-03-26)
 

--- a/Examples/uninstall.sh
+++ b/Examples/uninstall.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# uninstall.sh
+
+# removes Setup Checklist app and all related files
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+appName="Setup Checklist"
+bundleID="com.jamf.setupchecklist"
+
+appPath="/Applications/${appName}.app"
+
+if [ "$(whoami)" != "root" ]; then
+    echo "needs to run as root!"
+    exit 1
+fi
+
+echo "removing files"
+rm -rfv "$appPath"
+rm -v "/usr/local/bin/setupchecklist"
+rm -v /Library/LaunchAgents/"$bundleID".plist
+
+echo "forgetting $bundleID pkg receipt"
+pkgutil --forget "$bundleID"
+
+# always exit success regardless of exit code of above commands
+exit 0

--- a/Extras/CommandLineTool.md
+++ b/Extras/CommandLineTool.md
@@ -74,6 +74,6 @@ The values you can use are:
 - `movie`
 - `accentColor`
 - `item`
-- `actionButtonLabel`
+- `buttonLabel`
 
 (Note: not all combinations haven been tested yet. Please file issues, when something doesn't work as expected.)

--- a/Profile/ScriptStep.md
+++ b/Profile/ScriptStep.md
@@ -118,18 +118,18 @@ The activateScript might contain code that prepares the action. In some cases yo
 
 In our example, we don't really have anything to do at this time, so we don't add an `activateScript`. In most situations, you won't need to implement all script options.
 
-## Action Button Script
+## Button Script
 
-The `actionButtonScript` gets executed when the user clicks the button. In our example, we want to open the url that open the Remote Login pane in System Settings.
+The `buttonScript` gets executed when the user clicks the button. In our example, we want to open the url that open the Remote Login pane in System Settings.
 
 ```xml
-  <key>actionButtonScript</key>
+  <key>buttonScript</key>
   <string>open 'x-apple.systempreferences:com.apple.preferences.sharing?Services_RemoteLogin'</string>
-  <key>actionButtonLabel</key>
+  <key>buttonLabel</key>
   <string>Open Remote Login…</string>
 ```
 
-If you want to enable the 'Continue' button when the `buttonActionScript` is done, you need to do so explictly by setting the step's status to `canContinue` or `completed` with `setupchecklist status script-remote-login completed`.
+If you want to enable the 'Continue' button when the `buttonScript` is done, you need to do so explictly by setting the step's status to `canContinue` or `completed` with `setupchecklist status script-remote-login completed`.
 
 In our example, we do not want to automatically set the step as completed, but need to observe the state of the system until the user enables the 'Remote Login' service.
 
@@ -167,9 +167,9 @@ This brings us to this `script` step:
 
 ```xml
 <dict>
-  <key>actionButtonLabel</key>
+  <key>buttonLabel</key>
   <string>Open Remote Login…</string>
-  <key>actionButtonScript</key>
+  <key>buttonScript</key>
   <string>open 'x-apple.systempreferences:com.apple.preferences.sharing?Services_RemoteLogin'</string>
   <key>identifier</key>
   <string>script-remote-login</string>

--- a/Profile/SetupChecklist.md
+++ b/Profile/SetupChecklist.md
@@ -237,7 +237,7 @@ When a `movie` key is set, these keys control the behavior of the movie:
 <false/>
 ```
 
-### Window Position
+#### Window Position
 
 key: `windowPosition`, string, default: `center`
 
@@ -375,6 +375,12 @@ When enabled, the item will be opened automatically when the step is displayed.
 key: `hide`, boolean: default: false
 
 Launches the app or URL, but hides the app (or keeps the app in the background). This is useful when you need to launch a process that should not be visible to the user.
+
+#### Button Label
+
+key: `buttonLabel`, string, [localizable](Localization.md), optional, default depends on step kind
+
+The label used for the button.
 
 ### Default App
 
@@ -649,6 +655,99 @@ When enabled, the Screen Recording pane in System Settings app will be opened au
 <true/>
 ```
 
+### Dock
+
+kind: `dock`
+
+This step will inform their user of items that are recommended to add to the Dock. You can choose whether the user can opt to keep the current dock, add recommended items to the current dock or replace the current dock with the recommended configuration. The step will show a preview of the dock with each choice.
+
+Example:
+
+```xml
+<dict>
+  <key>dockAction</key>
+  <array>
+    <string>add</string>
+    <string>replace</string>
+  </array>
+  <key>dockItems</key>
+  <array>
+    <string>com.apple.systempreferences</string>
+    <string>com.apple.apps.launcher</string>
+    <string>com.jamf.selfserviceplus</string>
+    <string>/Applications/Google Chrome.app</string>
+    <string>com.microsoft.outlook</string>
+    <string>com.microsoft.teams2</string>
+    <string>Downloads</string>
+    <string>smb://server.example.com/share</string>
+  </array>
+  <key>identifier</key>
+  <string>dock</string>
+  <key>kind</key>
+  <string>dock</string>
+  <key>mayKeepCurrent</key>
+  <true/>
+  <key>message</key>
+  <string>For convienient access, we recommend adding these apps and items to your Dock.</string>
+</dict>
+```
+
+#### Dock Action
+
+key: `dockAction`, string or array of string, default: `add`
+
+This key controls the options available to user. The value for this key can be `keep`, `add`, or `replace` or an array with any combination of the three values.
+
+Setting `mayKeepCurrent` to `true` has the same effect as adding `keep` to `dockAction`. 
+
+Example:
+
+```xml
+<key>dockAction</key>
+<array>
+  <string>add</string>
+  <string>replace</string>
+</array>
+```
+
+#### Dock Items
+
+key: `dockItems`, array of strings
+
+This is a list of items, which will be added to the Dock.
+
+Note that all apps will be added to the left (leading) side of the dock and folders, files, and URLs will added to the right (trailing) side, in order.
+
+Finder and Trash are fixed in the Dock and do not need to be listed here, nor can they be removed.
+
+Each item is a string and can be:
+
+- an absolute path to an app, e.g. `/Applications/Google Chrome.app`
+- a bundle identifier of an app, e.g. `com.apple.systempreferences` or `com.jamf.selfserviceplus`
+- an absolute path to a folder or file
+- a relative path to a folder or file, which will be resolved relative to the current user's home directory, e.g. `Downloads` will be resolved to `/Users/username/Downloads`
+- an URL, e.g. `https://jamf.com` or `smb://server.example.com/share`
+
+```xml
+<key>dockItems</key>
+<array>
+  <string>com.apple.systempreferences</string>
+  <string>com.apple.apps.launcher</string>
+  <string>com.jamf.selfserviceplus</string>
+  <string>/Applications/Google Chrome.app</string>
+  <string>com.microsoft.outlook</string>
+  <string>com.microsoft.teams2</string>
+  <string>Downloads</string>
+  <string>smb://server.example.com/share</string>
+</array>
+```
+
+#### May keep current
+
+key; `mayKeepCurrent`, boolean, optional, default: false
+
+When this flag is set to `true` Setup Checklist gives the user a choice to keep their current dock configuration. Setting `mayKeepCurrent` to `true` has the same effect as adding `keep` to `dockAction`. This key exists to provide consistency with other steps that use `mayKeepCurrent`.
+
 ### Script
 
 kind: `script`
@@ -682,6 +781,10 @@ if [ -n $DEBUG ]; then
 fi
 ```
 
+#### Open Step keys
+
+The `script` step is an extension of the `open` step. This means that all keys specific to the `open` step can be used with `script` step, as well.
+
 #### Lifecycle
 
 App launches/Step is loaded:
@@ -700,7 +803,7 @@ Script is selected/activated:
 
 Action Button clicked or opened automatically:
 
-- `actionButtonScript`
+- `buttonScript`
 
 Status set to `completed`:
 
@@ -741,7 +844,7 @@ If you have a more complicated system that you want launch automatically when th
 
 #### Action Button Script
 
-key: `actionButtonScript`, String, optional
+key: `buttonScript`, String, optional
 
 This script is executed when the user clicks the action button or `openAutomatically` is set which sets of this script when the step is shown.
 
@@ -765,6 +868,6 @@ When the `updateStatusScript` returns an exit code of `0`/success, the step's st
 
 key: `willContinueScript`, String, optional
 
-This script is called when the user clicks the 'Continue' button. Use this script to 'clean up' things created or launched in activate phase or actionButtonScript. For example, you can quit an app that was launched.
+This script is called when the user clicks the 'Continue' button. Use this script to 'clean up' things created or launched in activate phase or button script. For example, you can quit an app that was launched.
 
 **Default behavior:** None

--- a/Profile/Welcome.md
+++ b/Profile/Welcome.md
@@ -40,7 +40,7 @@ Skip Welcome screen (and language chooser)
 
 #### Title
 
-key: `title`, string, optional, [localizable](../Extras/Localization.md), default: `Welcome`, localized to current language
+key: `title`, string, optional, [localizable](Localization.md), default: `Welcome`, localized to current language
 
 Use this to customize the welcome message shown. When there is a single string value, it will be used for all languages. When the localization dict does not provide a localization for the current language, it will fall back to the `en` localization
 
@@ -75,7 +75,7 @@ key: `background`, string, optional, default: default system background image
 
 Local path to an image that is used as the background for the welcome screen.
 
-(**Note:** this does _not_ use the [image source](../Extras/ImageSources.md) syntax yet.)
+(**Note:** this does _not_ use the [image source](ImageSources.md) syntax yet.)
 
 Example:
 
@@ -99,8 +99,8 @@ Example:
 
 #### Title Color, Button Color
 
-key: `titleColor`, string/[color definition](../Extras/DefiningColors.md), optional
-key: `buttonColor`, string/[color definition](../Extras/DefiningColors.md), optional
+key: `titleColor`, string/[color definition](DefiningColors.md), optional
+key: `buttonColor`, string/[color definition](DefiningColors.md), optional
 
 By default, the Welcome app calculates the overall "lightness" of the background image and displays the title text and the buttons in a white font color for dark images and and black font color for light images.
 


### PR DESCRIPTION
### Setup Checklist

- NEW: `dock` step kind (#17)
- added `buttonLabel` key to `open`, `script`, and `screensharing` steps to override button label text
- improved scrolling and responsiveness of `wallpaper` with many images
- localization fixes (#42)
- added toolbar button to show list when it is hidden
- fixed a user interface issue where the action button disappears when window is not active
- images and movies scale up when window size is increased

### Welcome app

- fixed an issue where the welcome screen may not go full screen

### General

- added uninstall script
- documentation updates (#45)

### Deprecations and Removals

- `browser` step kind has been _removed_. Use `defaultApp` with a `urlScheme` of `http` instead
- `actionButtonLabel` and `actionButtonScript` keys are simplified to `buttonLabel` and `buttonScript`. The old long forms will keep working for now, but be removed in some future update. (#43)