### PR TITLE
v1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,31 @@
 #  Setup Checklist - Change Log
 
+## v1.0
+(2026-06-12)
+
+### Setup Checklist
+- wallpaper step 
+  - now displays image files containing dark and light mode versions, _see notes_
+  - display performance improvements
+- dock step
+  - should now properly determine status in some edge cases (#48)
+- open and script step
+  - `openAutomatically` does not trigger on select when step is already marked `completed` (#62)
+- user interface fixes (#63)
+
+### Automation
+- new command line tool and url scheme commands:
+  - `reload`: reload steps from defaults/profile
+  - `next`: go to next step
+  - `list`: list steps in current configuration
+
+### Notes:
+
+#### Wallpaper: 
+
+There are at least three different variants of combined or dynamic wallpapers. The simplest contains a light and dark version of the wallpaper, the second contains several different images which are chosen according to time of day and the last contains different versions chosen according to solar position (calculated from location, time of day and season). Setup Manager will display a combined preview for the simplest case: dark/light mode. For the other variants, the first image resource will be used for the preview. After selecting the image, the proper image should be used for the wallpaper.
+
+
 ## v0.4.0
 (2026-04-09)
 

--- a/Examples/Setup Checklist Complete.mobileconfig
+++ b/Examples/Setup Checklist Complete.mobileconfig
@@ -245,16 +245,16 @@
 					<key>kind</key>
 					<string>message</string>
 					<key>message</key>
-					<dict>
-						<key>de</key>
-						<string>Die Konfiguration is abgeschlossen. Sie können diese Einstellungen wiederholen, indem sie die Welcome.app wieder starten. Viel Vergnügen mit Ihrem Mac!</string>
-						<key>en</key>
-						<string>The configuration is complete. You can re-apply these settings by running the Welcome.app again. Enjoy your Mac!</string>
-						<key>fr</key>
-						<string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l'application Welcome. Profitez de votre Mac!</string>
-						<key>nl</key>
-						<string>De configuratie is voltooid. U kunt deze instellingen opnieuw toepassen door de Welcome.app opnieuw uit te voeren. Veel plezier met uw Mac!</string>
-					</dict>
+          <dict>
+            <key>de</key>
+            <string>Die Konfiguration is abgeschlossen. Sie können diese Einstellungen wiederholen, indem Sie die Setup Checklist App wieder starten. Viel Vergnügen mit Ihrem Mac!</string>
+            <key>en</key>
+            <string>The configuration is complete. You can re-apply these settings by running the Setup Checklist again. Enjoy your Mac!</string>
+            <key>fr</key>
+            <string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l'application Setup Welcome. Profitez de votre Mac!</string>
+            <key>nl</key>
+            <string>De configuratie is voltooid. U kunt deze instellingen opnieuw toepassen door de Setup Checklist app opnieuw uit te voeren. Veel plezier met uw Mac!</string>
+          </dict>
 					<key>title</key>
 					<dict>
 						<key>de</key>

--- a/Examples/com.jamf.setupchecklist.plist
+++ b/Examples/com.jamf.setupchecklist.plist
@@ -9,7 +9,7 @@
 	<key>icon</key>
 	<string>name:Checklist</string>
 	<key>message</key>
-	<string>Let&apos;s configure your new Mac!</string>
+	<string>Let's configure your new Mac!</string>
 	<key>showIconInDock</key>
 	<true/>
 	<key>steps</key>
@@ -51,8 +51,6 @@
 			<string>wallpaper</string>
 			<key>kind</key>
 			<string>wallpaper</string>
-			<key>path</key>
-			<string>/Library/Desktop Pictures/</string>
 			<key>message</key>
 			<dict>
 				<key>de</key>
@@ -60,10 +58,12 @@
 				<key>en</key>
 				<string>Please choose a wallpaper from our list of branded images. You can always change it later.</string>
 				<key>fr</key>
-				<string>Veuillez choisir un fond d&apos;écran dans notre liste d&apos;images. Vous pouvez toujours le changer plus tard.</string>
+				<string>Veuillez choisir un fond d'écran dans notre liste d'images. Vous pouvez toujours le changer plus tard.</string>
 				<key>nl</key>
 				<string>Kies een achtergrond uit onze lijst met afbeeldingen. Je kunt het altijd later veranderen.</string>
 			</dict>
+			<key>path</key>
+			<string>/Library/Desktop Pictures/</string>
 			<key>title</key>
 			<dict>
 				<key>de</key>
@@ -71,9 +71,45 @@
 				<key>en</key>
 				<string>Choose a wallpaper</string>
 				<key>fr</key>
-				<string>Choisir un fond d&apos;écran</string>
+				<string>Choisir un fond d'écran</string>
 				<key>nl</key>
 				<string>Kies een achtergrond</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>dockAction</key>
+			<array>
+				<string>replace</string>
+				<string>add</string>
+			</array>
+			<key>dockItems</key>
+			<array>
+				<string>com.apple.systempreferences</string>
+				<string>com.apple.apps.launcher</string>
+				<string>com.jamf.selfserviceplus</string>
+				<string>/Applications/BBEdit.app</string>
+				<string>com.microsoft.outlook</string>
+				<string>com.microsoft.teams2</string>
+				<string>Downloads</string>
+				<string>Documents</string>
+				<string>smb://server.example.com/share</string>
+			</array>
+			<key>identifier</key>
+			<string>dock</string>
+			<key>kind</key>
+			<string>dock</string>
+			<key>mayKeepCurrent</key>
+			<false/>
+			<key>message</key>
+			<dict>
+				<key>de</key>
+				<string>Für einen leichteren Zugriff empfehlen wir, diese Apps und Ordner Ihrem Dock hinzuzufügen.</string>
+				<key>en</key>
+				<string>For convienient access, we recommend adding these apps and items to your Dock.</string>
+				<key>fr</key>
+				<string>Pour un accès pratique, nous vous recommandons d'ajouter ces applications et éléments à votre Dock.</string>
+				<key>nl</key>
+				<string>Voor gemakkende toegang raden we aan deze apps en items aan je Dock toe te voegen.</string>
 			</dict>
 		</dict>
 		<dict>
@@ -141,7 +177,7 @@
 				<key>en</key>
 				<string>Choose Mail App</string>
 				<key>fr</key>
-				<string>Choisir l&apos;application Mail</string>
+				<string>Choisir l'application Mail</string>
 				<key>nl</key>
 				<string>Kies de Mail-app</string>
 			</dict>
@@ -167,7 +203,7 @@
 				<key>en</key>
 				<string>Enable Screen &amp; System Audio Recording for Microsoft Teams</string>
 				<key>fr</key>
-				<string>Activer l&apos;enregistrement de l&apos;écran et des sons du système pour Microsoft Teams</string>
+				<string>Activer l'enregistrement de l'écran et des sons du système pour Microsoft Teams</string>
 				<key>nl</key>
 				<string>Scherm- en systeemaudio-opname inschakelen voor Microsoft Teams</string>
 			</dict>
@@ -197,13 +233,13 @@
 			<key>message</key>
 			<dict>
 				<key>de</key>
-				<string>Die Konfiguration is abgeschlossen. Sie können diese Einstellungen wiederholen, indem sie die Welcome.app wieder starten. Viel Vergnügen mit Ihrem Mac!</string>
+				<string>Die Konfiguration is abgeschlossen. Sie können diese Einstellungen wiederholen, indem Sie die Setup Checklist App wieder starten. Viel Vergnügen mit Ihrem Mac!</string>
 				<key>en</key>
-				<string>The configuration is complete. You can re-apply these settings by running the Welcome.app again. Enjoy your Mac!</string>
+				<string>The configuration is complete. You can re-apply these settings by running the Setup Checklist again. Enjoy your Mac!</string>
 				<key>fr</key>
-				<string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l&apos;application Welcome. Profitez de votre Mac!</string>
+				<string>La configuration est terminée. Vous pouvez réappliquer ces paramètres en exécutant à nouveau l'application Setup Welcome. Profitez de votre Mac!</string>
 				<key>nl</key>
-				<string>De configuratie is voltooid. U kunt deze instellingen opnieuw toepassen door de Welcome.app opnieuw uit te voeren. Veel plezier met uw Mac!</string>
+				<string>De configuratie is voltooid. U kunt deze instellingen opnieuw toepassen door de Setup Checklist app opnieuw uit te voeren. Veel plezier met uw Mac!</string>
 			</dict>
 			<key>title</key>
 			<dict>

--- a/Extras/CommandLineTool.md
+++ b/Extras/CommandLineTool.md
@@ -14,6 +14,28 @@ Most commands will require Setup Checklist to be running to work properly. You c
 $ setupchecklist launch
 ```
 
+## List steps
+
+You can list the steps in the current configuration.
+
+```shell
+$ setupchecklist list
+welcome-message, kind: message
+dock, kind: dock
+wallpaper, kind: wallpaper
+```
+
+The output will be in the format `<identifier> , kind: <kind>`
+
+When you add the `--identifiers/-i` flag, it will list only the identifiers of the steps.
+
+```shell
+$ setupchecklist list -i           
+welcome-message
+dock
+wallpaper
+```
+
 ## Get current step
 
 Running `setupchecklist current` will return the identifier of the current step:
@@ -29,6 +51,14 @@ You can tell Setup Checklist to go to a specific step, determined by the steps i
 
 ```shell
 $ setupchecklist goto <identifier>
+```
+
+## Go to Next Step
+
+This will go to the next step.
+
+```shell
+$ setupchecklist next
 ```
 
 ## Get and update status
@@ -77,3 +107,12 @@ The values you can use are:
 - `buttonLabel`
 
 (Note: not all combinations haven been tested yet. Please file issues, when something doesn't work as expected.)
+
+## Reload Steps
+
+This will tell Setup Checklist to reload all steps from the defaults or profile and start over.
+
+```shell
+$ setupchecklist reload
+```
+

--- a/Extras/URLScheme.md
+++ b/Extras/URLScheme.md
@@ -18,6 +18,12 @@ You can tell Setup Checklist to launch and go to a specific step, determined by 
 
 Example: `jamf-setupchecklist:goto/browser-edge`
 
+## Go to Next Step
+
+This will go to the next step.
+
+Example: `jamf-setupchecklist:next`
+
 ## Change Status
 
 You can change the `completed` status of a step with this call.
@@ -29,3 +35,10 @@ You can change the `completed` status of a step with this call.
 Note that many will recalculate the completed status when the step is loaded and right before it is shown, so manually overwriting the completed status may have limited effect.
 
 Valid values are `completed`, `suggested`, `error`
+
+## Reload Steps
+
+This will tell Setup Checklist to reload all steps from the defaults or profile and start over.
+
+Example: `jamf-setupchecklist:reload`
+

--- a/Profile/SetupChecklist.md
+++ b/Profile/SetupChecklist.md
@@ -177,7 +177,7 @@ The image shown at the top of the step area. When the `image` has a value, that 
 
 Some step kinds will have other defaults for the image, i.e. the `browser` step will use the target default browser's app icon. 
 
-The size of the area available to the image will vary with window size and position, but 16:9 ratio landscape or square images work well.
+The size of the area available to the image will vary with window size and position, but 16:9 ratio landscape or square images work well. The available space in the default window is approximately 630 x 440 pixels (1260x 880 @ 2x) but this will change should the user choose to change window size, or with a long `message` text.
 
 ```xml
 <key>image</key>
@@ -209,7 +209,7 @@ The `movie` can be an absolute path to a local movie file or a `https` url.
 
 The movie will loop (start over when it reaches the end) and is muted. Animated GIFs do _not_ work as movies.
 
-The size of the area available to the image will vary with window size and position, but 16:9 ratio landscape or square movies work well.
+The size of the area available to the image will vary with window size and position, but 16:9 ratio landscape or square movies work well. The available space in the default window is approximately 630 x 440 pixels (1260x 880 @ 2x) but this will change should the user choose to change window size. A 720p movie resolution is the recommended minimum, but a 1080p would not be wasteful. Remember that you can drastically reduce the file size of most videos with little quality loss using tools like `ffmpeg` or [Handbrake](https://handbrake.fr)
 
 ```xml
 <key>movie</key>
@@ -488,7 +488,7 @@ key: `bundle-id`, string or array of strings, required
 
 The app [bundle identifier](../Extras/BundleIdentifiers.md) for the browser, e.g. `org.mozilla.firefox`. When the app cannot be found when Welcome app runs (i.e. the browser is not installed yet, this step will be skipped)
 
-You can use [`utiluti`](https://github.com/scriptingsox/utiluti) to get a list of apps and their bundle identifiers for a given url scheme or universal type identifier:
+You can use [`utiluti`](https://github.com/scriptingosx/utiluti) to get a list of apps and their bundle identifiers for a given url scheme or universal type identifier:
 
 ```shell
 $ utiluti url list mailto --bundle-id
@@ -551,7 +551,7 @@ When multiple values are given the first value is used is used to determine the 
 
 When both `urlScheme` and `uniformTypeIdentifier` values are provided the first `urlScheme` is used to determine the current default app and whether changing the app succeeded.
 
-You can get the uniform type identifier from a file extension using [`utiluti`](https://github.com/scriptingsox/utiluti):
+You can get the uniform type identifier from a file extension using [`utiluti`](https://github.com/scriptingosx/utiluti):
 
 ```shell
 $ utiluti get-uti pdf
@@ -581,9 +581,14 @@ This step will open the Screen Recording pane in Settings > Privacy & Security a
 
 **Important:** this steps _requires_ the "Full Disk Access" privacy access enabled, which in a managed environment [is best granted with a PPPC profile.](Overview.md#managed-login-items-and-privacy-preferences-policy-control).
 
-This step works well with a `windowPosition` setting of `left` or `right`
+**Note:** macOS 26 System Settings app will _not_ automatically list apps which might require this approval. The user will have to click on the '+' at the bottom of the list and select the app.
+
+Admins can pre-populate this pane by providing a PPPC profile for the apps to allow standard users to allow screen sharing. This will pre-populate the app(s) in the Screen & System Audio Recording pane, with the note "This setting has been configured by a profile," whether the user is admin or not.
+
 
 ![Setup Checklist screensharing step keys](../Images/SetupChecklist-screensharing-keys.png)
+
+This step works well with a `windowPosition` setting of `left` or `right`
 
 Example: 
 
@@ -854,9 +859,9 @@ This script is executed when the user clicks the action button or `openAutomatic
 
 key: `updateStatusScript`, String, optional
 
-The `updateStatusScript` behaves differently than other scripts. This script is called at different times during a step's lifecycle. It should evaluate the facts on the system and return and exit code of `0` (success) when the fact match the desired outcome and and exit code of `1` (failure) when the don't.
+The `updateStatusScript` behaves differently than other scripts. This script is called at different times during a step's lifecycle. It should evaluate the facts on the system and return an exit code of `0` (success) when the fact matches the desired outcome and an exit code of `1` (failure) when it does not.
 
-The updateStatusScript is evaluated at the end of preparation (regardless of whether a `prepareScript` script exists). If the `updateScript` returns `0/success here, the step is immediately marked as completed and not shown in the normal workflow, unless the user explicitly clicks on it.
+The `updateStatusScript` is evaluated at the end of preparation (regardless of whether a `prepareScript` script exists). If the `updateScript` returns `0/success here, the step is immediately marked as completed and not shown in the normal workflow, unless the user explicitly clicks on it.
 
 If an `updateStatusScript` exists, clicking the action button will start a polling cycle that evaluates the `updateStatusScript` _once per second_. For this reason, the update status script needs to be small and fast. The idea here is that the polling cycle monitors the desired outcome and sets the step to completed when that occurs.
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ Admins can deploy Setup Checklist together with configuration profile to guide t
 
 Setup Checklist works with **Jamf Pro** and **Jamf School**.
 
-## BETA Warning!
+## Call to action
 
-This tool is still in beta. While we do test the app and do our best to make sure everything is working, you might quickly leave the 'happy path' in your testing and run into bugs or things that may not work as expected. [Your feedback](https://github.com/Jamf-Concepts/setup-checklist/issues) is required and much appreciated for us to identify and address these issues. Thank you.
-
-This also means that features and the format of the configuration profile might change from one beta version to the next. We will do our best to document these changes, but be prepared that you might have to update the configuration profile you built frequently.
+While we do test the app and do our best to make sure everything is working, this is a very flexible tool that can be used in many different situations and environments. When you run into bugs or things that may not work as expected, [your feedback](https://github.com/Jamf-Concepts/setup-checklist/issues) is required and much appreciated for us to identify and address these issues. Thank you.
 
 ## Installer and Updates
 
@@ -57,7 +55,6 @@ Updates are published in the '[Releases](https://github.com/Jamf-Concepts/setup-
 - there is a limited number of steps right now, we have plans for more, but your feedback on which kinds of steps you need is appreciated and will help us prioritize
 - `background` key in Welcome screen only allows local files
 - there is no custom JSON to get a custom profile interface in Jamf Pro and we are not planning to provide one until the profile schema is stable
-- there is known issue in Self Service Plus where launching an action through a URL stalls in Self Service Plus
 
 ## Feedback
 


### PR DESCRIPTION
### Setup Checklist
- wallpaper step 
  - now displays image files containing dark and light mode versions, _see notes_ (#204)
  - display performance improvements
- dock step
  - should now properly determine status in some edge cases (#198, jamf-concepts/setup-checklist#48)
- open and script step
  - `openAutomatically` does not trigger on select when step is already marked `completed` (#208, jamf-concepts/setup-checklist#62)
- user interface fixes (#185, #188, #210, Jamf-Concepts/setup-checklist#63)

### Automation
- new command line tool and url scheme commands:
  - `reload`: reload steps from defaults/profile (#93)
  - `next`: go to next step (#100)
  - `list`: list steps in current configuration (#195)

### Notes:

#### Wallpaper: 

There are at least three different variants of combined or dynamic wallpapers. The simplest contains a light and dark version of the wallpaper, the second contains several different images which are chosen according to time of day and the last contains different versions chosen according to solar position (calculated from location, time of day and season). Setup Manager will display a combined preview for the simplest case: dark/light mode. For the other variants, the first image resource will be used for the preview. After selecting the image, the proper image should be used for the wallpaper.
